### PR TITLE
Migrate docker image to alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@
 
 
 
-FROM node:12 AS build
+FROM node:12-alpine AS build
 
 WORKDIR /app
 
@@ -45,11 +45,12 @@ ENV VERSION_SHA=$CI_COMMIT_SHA
 
 ADD . .
 # temporarily install dependencies for building packages
-RUN apt-get update && apt-get install -y build-essential python g++ cmake \
+#RUN apt-get update && apt-get install -y build-essential python g++ cmake \
+RUN apk -U add build-base python \
     && npm install \
     && npm run build
 
-FROM node:12
+FROM node:12-alpine
 WORKDIR /app
 COPY --from=build /app/js /app/js
 COPY --from=build /app/contracts /app/contracts


### PR DESCRIPTION
Reduce the docker image size (uncompressed) from 1.08GB to 252MB

```
$ docker images | grep in3-node
in3-node                                      alpine              1b4a4efe39eb        25 minutes ago       252MB
in3-node                                      latest              c4ee6357880e        3 hours ago          1.08GB
```